### PR TITLE
Driver controlled steady arm driving

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -157,6 +157,7 @@ public final class Constants {
   public static final double ELBOW_TOLERANCE = ELBOW_ROTATIONS_PER_DEGREE / 2.0;
   public static final double ELBOW_NUDGE_DEGREES = 3.0;
   public static final int ELBOW_ENCODER_COUNT_PER_REV = 8192;
+  public static final double ELBOW_POSITION_OFFSET = 9;
 
   public static final double SHOULDER_ROTATIONS_PER_DEGREE = 500.0 / 360.0;
   // needs fixing; moves to fast and with to much force.
@@ -169,6 +170,7 @@ public final class Constants {
   public static final double SHOULDER_NUDGE_DEGREES = 3.0; //Placeholder value, this will 
   public static final int SHOULDER_ENCODER_COUNT_PER_REV = 8192;
   public static final double SHOULDER_ENCODER_ROTATIONS_PER_DEGREE = 1.89;
+  public static final double SHOULDER_POSITION_OFFSET = 3.5;
   
   public static final double WRIST_ROTATIONS_PER_DEGREE = 60.0 / 360.0;
   //TODO maybe tune this?

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -21,6 +21,7 @@ import frc.robot.commands.IntakeCommand;
 import frc.robot.commands.MoveConeHighCommand;
 import frc.robot.commands.MoveConeMiddleCommand;
 import frc.robot.commands.ScoreCommand;
+import frc.robot.commands.SquareUpAndDrive;
 import frc.robot.commands.autonomous.BalanceAuto;
 import frc.robot.commands.autonomous.ConeHighBalance;
 import frc.robot.commands.autonomous.DriveUntilCommand;
@@ -199,8 +200,13 @@ public class RobotContainer {
     // m_armSubsystem.setKnownArmPlacement(KnownArmPlacement.SINGLE_SUBSTATION)));
     m_primaryController.rightBumper().whileTrue(new IntakeCommand(m_intakeSubsystem));
     m_primaryController.leftBumper().whileTrue(new ScoreCommand(m_intakeSubsystem));
-    // Try onTrue for command actuation, might be interesting
-    // Substation grabs
+
+    // Substation (maybe score) approach driving
+    m_primaryController.a().whileTrue(new SquareUpAndDrive(
+        m_driveSubsystem,
+        () -> modifyAxis(m_primaryController.getLeftY()) * Constants.MAX_VELOCITY_METERS_PER_SECOND,
+        () -> modifyAxis(m_primaryController.getLeftX()) * Constants.MAX_VELOCITY_METERS_PER_SECOND));
+
     // Driver nudges
     m_primaryController.povUp()
         .whileTrue(new RunCommand(() -> m_driveSubsystem.drive(-1.0, 0.0, 0.0, true),

--- a/src/main/java/frc/robot/commands/SquareUpAndDrive.java
+++ b/src/main/java/frc/robot/commands/SquareUpAndDrive.java
@@ -1,0 +1,88 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import java.util.function.DoubleSupplier;
+
+import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.math.filter.SlewRateLimiter;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.DriveSubsystem;
+import frc.robot.subsystems.DriveSubsystem.FieldRelativeSpeeds;
+
+/**
+ * This command squares the robot up to the nearest 909 degrees and limits the
+ * velocity rate of change (accel and decel) for both the X and Y directions.
+ * The goal is to allow the driver to continue to control the robot on approach
+ * to a substation or scoring position while keeping the arm steady.
+ * 
+ * <p>
+ * Note that the driver does NOT need to stop before initiating this drive mode.
+ * The slew rate limiters are initialized with the current speeds.
+ * </p>
+ */
+public class SquareUpAndDrive extends CommandBase {
+  private final DriveSubsystem m_driveSubsystem;
+  private final PIDController m_rotationController = new PIDController(0.03, 0, 0);
+  private final DoubleSupplier m_forwardSupplier;
+  private final SlewRateLimiter m_forwardLimiter = new SlewRateLimiter(1.0);
+  private final DoubleSupplier m_strafeSupplier;
+  private final SlewRateLimiter m_strafeLimiter = new SlewRateLimiter(1.0);
+
+  public SquareUpAndDrive(final DriveSubsystem driveSubsystem,
+      final DoubleSupplier forwardSupplier,
+      final DoubleSupplier strafeSupplier) {
+    m_driveSubsystem = driveSubsystem;
+    m_forwardSupplier = forwardSupplier;
+    m_strafeSupplier = strafeSupplier;
+    addRequirements(m_driveSubsystem);
+    m_rotationController.enableContinuousInput(-180.0, 180.0);
+    m_rotationController.setTolerance(0.05);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    m_rotationController.reset();
+    final double angle = m_driveSubsystem.getPose().getRotation().getDegrees();
+    final double absAngle = Math.abs(angle);
+    final boolean closerTo0 = (180.0 - absAngle) > absAngle;
+    final boolean closerTo90 = absAngle > 45.0 && absAngle < 135.0;
+    if (closerTo90) {
+      m_rotationController.setSetpoint(90.0 * Math.signum(angle));
+    } else {
+      m_rotationController.setSetpoint(closerTo0 ? 0.0 : 180.0);
+    }
+
+    // Initialize the SlewRateLimiters with the current speeds for
+    // smoothe transition between drive types.
+    final FieldRelativeSpeeds fieldRelSpeeds = m_driveSubsystem.getFieldRelativeSpeeds();
+    m_forwardLimiter.reset(fieldRelSpeeds.vxMetersPerSecond);
+    m_strafeLimiter.reset(fieldRelSpeeds.vyMetersPerSecond);
+    // TODO Should we attempt to start squaring rotation at current rate?
+    // Probably more trouble than it is worth.
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    // Calculate the rotation
+    final double rawAngle = m_driveSubsystem.getPose().getRotation().getDegrees();
+    double rotationRate = m_rotationController.calculate(rawAngle);
+    rotationRate += 1.0 * Math.signum(rotationRate);
+
+    // Get the forward and limit the acceleration.
+    final double forwardVelocity = m_forwardLimiter.calculate(m_forwardSupplier.getAsDouble());
+
+    // Get the strafe and limit the acceleration.
+    final double strafeVelocity = m_strafeLimiter.calculate(m_strafeSupplier.getAsDouble());
+
+    m_driveSubsystem.drive(
+        forwardVelocity,
+        strafeVelocity,
+        rotationRate,
+        true);
+  }
+}

--- a/src/main/java/frc/robot/subsystems/ArmSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ArmSubsystem.java
@@ -52,7 +52,7 @@ public class ArmSubsystem extends SubsystemBase {
     FLOOR_GRAB_CONE(80.0, -80.0, 33.0), // TODO: Change to intake knocked over cones
     FLOOR_GRAB_CUBE(54.0, -80.0, 30.0),
     FLOOR_GRAB_PRE(54.0, -80.0, 0.0),
-    SUBSTATION_APPROACH(108.0, 5.7, 0.0),
+    SUBSTATION_APPROACH(108.0, 5.7, 5.0),
     SUBSTATION_GRAB_HALFWAY_CUBE(108.0, 3.0, 85.0),
     SUBSTATION_GRAB_HALFWAY_CONE(108.0, 20.0, 145.0),
     SUBSTATION_GRAB_FULLWAY_CUBE(91.4, 0.9, 60.0),
@@ -61,9 +61,9 @@ public class ArmSubsystem extends SubsystemBase {
     SINGLE_SUBSTATION_CONE(108.0, -42.5, 24.0),
     SCORE_LOW_CUBE(90.0, -53.0, 0.0),
     SCORE_LOW_CONE(90.0, -53.0, 40.0),
-    SCORE_MIDDLE_CUBE(100, -1.0, 85.0),
+    SCORE_MIDDLE_CUBE(100.0, -1.0, 85.0),
     // SCORE_CONE_MIDDLE_UPPER(63.0, 35.0, 150.0),
-    SCORE_CONE_MIDDLE(95.5, 10.0, 150.0),
+    SCORE_CONE_MIDDLE(95.5, 16.0, 162.0),
     SCORE_CUBE_HIGH(56.0, 26.0, 60.0),
     SCORE_CONE_HIGH_PRE(55.0, 40.0, 0.0),
     SCORE_CONE_HIGH(64.0, 36.0, 0.0),
@@ -185,8 +185,8 @@ public class ArmSubsystem extends SubsystemBase {
    */
   public void setKnownArmPlacement(final KnownArmPlacement placement) {
     double shoulderRotation = m_shoulderEncoder.getPosition();
-    double desiredShoulderAngle = placement.m_shoulderAngle;
-    double desiredElbowAngle = placement.m_elbowAngle - placement.m_shoulderAngle + 90;
+    double desiredShoulderAngle = placement.m_shoulderAngle + Constants.SHOULDER_POSITION_OFFSET;
+    double desiredElbowAngle = placement.m_elbowAngle + Constants.ELBOW_POSITION_OFFSET - placement.m_shoulderAngle + 90;
     double desiredWristAngle = placement.m_wristAngle;
     setWristPosition(desiredWristAngle);
     if (shoulderRotation < desiredShoulderAngle) {
@@ -296,7 +296,7 @@ public class ArmSubsystem extends SubsystemBase {
   public void seedRelativeEncoders() {
     m_elbowEncoder.setPosition(getCalculatedElbowAngle());
     m_shoulderEncoder.setPosition(getCalculatedShoulderAngle());
-    m_wristEncoder.setPosition(getCalculatedWristAngle());
+    m_wristEncoder.setPosition(m_wristThrougboreEncoder.getPosition());
   }
 
   /**
@@ -344,7 +344,7 @@ public class ArmSubsystem extends SubsystemBase {
   public void setTargetsToCurrents() {
     m_targetShoulderPosition = getCalculatedShoulderAngle();
     m_targetElbowPosition = getCalculatedElbowAngle();
-    m_targetWristPosition = getCalculatedWristAngle();
+    m_targetWristPosition = m_wristThrougboreEncoder.getPosition();
     m_lastPlacement = null;
   }
 

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -59,6 +59,14 @@ public class DriveSubsystem extends SubsystemBase {
   // Odometry
   private final SwerveDriveOdometry m_odometry;
 
+  /**
+   * The last set of ChassisSpeeds sent to or calcuated in drive(...). Note that
+   * this set of speeds is <b>NOT</b> desaturated. It should only be used when
+   * moderate and generally straight drive is expected. For example, during floor
+   * intake or substation approach.
+   */
+  private ChassisSpeeds m_lastChassisSpeeds = new ChassisSpeeds();
+
   public DriveSubsystem() {
     m_pigeon.setYaw(0.0);
     m_odometry = new SwerveDriveOdometry(Constants.DRIVE_KINEMATICS,
@@ -76,10 +84,10 @@ public class DriveSubsystem extends SubsystemBase {
    *                      field.
    */
   public void drive(double xSpeed, double ySpeed, double rot, boolean fieldRelative) {
-    var swerveModuleStates = Constants.DRIVE_KINEMATICS.toSwerveModuleStates(
-        fieldRelative
-            ? ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rot, Rotation2d.fromDegrees(m_pigeon.getYaw()))
-            : new ChassisSpeeds(xSpeed, ySpeed, rot));
+    m_lastChassisSpeeds = fieldRelative
+        ? ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rot, Rotation2d.fromDegrees(m_pigeon.getYaw()))
+        : new ChassisSpeeds(xSpeed, ySpeed, rot);
+    final SwerveModuleState[] swerveModuleStates = Constants.DRIVE_KINEMATICS.toSwerveModuleStates(m_lastChassisSpeeds);
     SwerveDriveKinematics.desaturateWheelSpeeds(swerveModuleStates, Constants.MAX_VELOCITY_METERS_PER_SECOND);
     setModuleStates(swerveModuleStates);
   }
@@ -95,6 +103,15 @@ public class DriveSubsystem extends SubsystemBase {
 
   public Rotation2d getRotation2d() {
     return Rotation2d.fromDegrees(m_pigeon.getFusedHeading());
+  }
+
+  /**
+   * Note that this set of speeds is <b>NOT</b> desaturated. It should only be
+   * used when moderate and generally straight drive is expected. For example,
+   * during floor intake or substation approach.
+   */
+  public FieldRelativeSpeeds getFieldRelativeSpeeds() {
+    return FieldRelativeSpeeds.fromChassisSpeeds(m_lastChassisSpeeds, getRotation2d());
   }
 
   /** Updates the field relative position of the robot. */
@@ -149,5 +166,58 @@ public class DriveSubsystem extends SubsystemBase {
     SmartDashboard.putNumber("Pitch", m_pigeon.getPitch());
     SmartDashboard.putBoolean("On Charge Station", onChargeStation());
     SmartDashboard.putBoolean("On Pitch Down", onPitchDown());
+  }
+
+  /**
+   * A clone of {@link ChassisSpeeds} but for field relative speeds.
+   */
+  public static class FieldRelativeSpeeds {
+    /**
+     * Represents forward velocity w.r.t the field frame of reference. (Fwd is +)
+     */
+    public double vxMetersPerSecond;
+
+    /**
+     * Represents sideways velocity w.r.t the field frame of reference. (Left is +)
+     */
+    public double vyMetersPerSecond;
+
+    /** Represents the angular velocity of the robot frame. (CCW is +) */
+    public double omegaRadiansPerSecond;
+
+    /**
+     * Constructs a FieldRelativeSpeeds object.
+     *
+     * @param vxMetersPerSecond     Forward velocity.
+     * @param vyMetersPerSecond     Sideways velocity.
+     * @param omegaRadiansPerSecond Angular velocity.
+     */
+    public FieldRelativeSpeeds(
+        double vxMetersPerSecond, double vyMetersPerSecond, double omegaRadiansPerSecond) {
+      this.vxMetersPerSecond = vxMetersPerSecond;
+      this.vyMetersPerSecond = vyMetersPerSecond;
+      this.omegaRadiansPerSecond = omegaRadiansPerSecond;
+    }
+
+    /**
+     * Lifted from CD with slight modification.
+     */
+    public static FieldRelativeSpeeds fromChassisSpeeds(final ChassisSpeeds chassisSpeeds,
+        final Rotation2d robotAngle) {
+      // Gets the field relative X and Y components of the robot's speed in the X axis
+      double robotXXComp = robotAngle.getCos() * chassisSpeeds.vxMetersPerSecond;
+      double robotXYComp = robotAngle.getSin() * chassisSpeeds.vxMetersPerSecond;
+
+      // Gets the field relative X and Y components of the robot's speed in the Y axis
+      double robotYXComp = robotAngle.getSin() * chassisSpeeds.vyMetersPerSecond;
+      double robotYYComp = robotAngle.getCos() * chassisSpeeds.vyMetersPerSecond;
+
+      // Adds the field relative X and Y components of the robot's X and Y speeds to
+      // get the overall field relative X and Y speeds
+      double fieldX = robotXXComp + robotYXComp;
+      double fieldY = robotXYComp + robotYYComp;
+
+      return new FieldRelativeSpeeds(fieldX, fieldY, chassisSpeeds.omegaRadiansPerSecond);
+    }
   }
 }


### PR DESCRIPTION
/**
 * This command squares the robot up to the nearest 909 degrees and limits the
 * velocity rate of change (accel and decel) for both the X and Y directions.
 * The goal is to allow the driver to continue to control the robot on approach
 * to a substation or scoring position while keeping the arm steady.
 * 
 * <p>
 * Note that the driver does NOT need to stop before initiating this drive mode.
 * The slew rate limiters are initialized with the current speeds.
 * </p>
 */